### PR TITLE
Agregar demo de predicción de anemia (endpoints para modelo joblib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Barber Shop Manager
+# Barber Shop Manager + Demo de modelo de anemia
 
-Aplicación base construida con [FastAPI](https://fastapi.tiangolo.com/) para gestionar los servicios de una barbería: citas, referencias fotográficas, chat con clientes y catálogo de productos.
+Aplicación base construida con [FastAPI](https://fastapi.tiangolo.com/) para gestionar los servicios de una barbería y ahora incluir una **demo de predicción de anemia sin hemoglobina** usando un modelo `joblib`.
 
 ## Requisitos
 
@@ -23,6 +23,62 @@ uvicorn app.main:app --reload
 
 El servidor se iniciará en `http://127.0.0.1:8000`. La documentación interactiva de la API está disponible en `http://127.0.0.1:8000/docs`.
 
+## Demo: modelo de anemia (`joblib`)
+
+La API intenta cargar el modelo desde:
+
+- `app/models/anemia_model.joblib` (por defecto), o
+- variable de entorno `ANEMIA_MODEL_PATH`
+
+Ejemplo:
+
+```bash
+export ANEMIA_MODEL_PATH=/ruta/a/tu/modelo.joblib
+```
+
+### Features esperadas
+
+```python
+FEATURES = [
+    "RIDAGEYR", "RIAGENDR", "RIDEXPRG",
+    "LBXIRN", "LBXUIB", "LBDTIB", "LBDPCT",
+    "LBXFER", "LBXHSCRP",
+    "LBXRBCSI", "LBXMCVSI", "LBXMCHSI",
+    "LBXMC", "LBXRDW"
+]
+```
+
+### Endpoints de la demo
+
+- `GET /anemia/features`: devuelve la lista de columnas esperadas por el modelo.
+- `POST /anemia/predict`: recibe un JSON con las 14 features y retorna:
+  - `prediction` (valor numérico del modelo)
+  - `prediction_label` (`anemia` o `sin_anemia` cuando la salida sea 0/1)
+  - `probability` (si el modelo implementa `predict_proba`)
+
+Ejemplo de request:
+
+```bash
+curl -X POST "http://127.0.0.1:8000/anemia/predict" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "RIDAGEYR": 45,
+    "RIAGENDR": 1,
+    "RIDEXPRG": 0,
+    "LBXIRN": 70,
+    "LBXUIB": 240,
+    "LBDTIB": 310,
+    "LBDPCT": 22,
+    "LBXFER": 40,
+    "LBXHSCRP": 1.1,
+    "LBXRBCSI": 4.7,
+    "LBXMCVSI": 88,
+    "LBXMCHSI": 29,
+    "LBXMC": 33,
+    "LBXRDW": 13.2
+  }'
+```
+
 ## Funcionalidades principales
 
 - **Clientes**: registrar y listar información de contacto.
@@ -37,6 +93,7 @@ El servidor se iniciará en `http://127.0.0.1:8000`. La documentación interacti
 app/
 ├── database.py      # Manejo de SQLite y creación de tablas
 ├── main.py          # Definición de la API FastAPI
+├── models/          # Ubicación sugerida para modelos .joblib
 └── uploads/         # Almacenamiento local de referencias fotográficas
 ```
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,10 @@
-"""FastAPI application for managing a barber shop."""
+"""FastAPI application including a demo for anemia prediction."""
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
@@ -15,6 +16,24 @@ from .database import get_connection, init_db
 UPLOAD_DIR = Path(__file__).resolve().parent / "uploads"
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
+FEATURES = [
+    "RIDAGEYR",
+    "RIAGENDR",
+    "RIDEXPRG",
+    "LBXIRN",
+    "LBXUIB",
+    "LBDTIB",
+    "LBDPCT",
+    "LBXFER",
+    "LBXHSCRP",
+    "LBXRBCSI",
+    "LBXMCVSI",
+    "LBXMCHSI",
+    "LBXMC",
+    "LBXRDW",
+]
+MODEL_PATH = Path(os.getenv("ANEMIA_MODEL_PATH", "app/models/anemia_model.joblib"))
+
 app = FastAPI(title="Barber Shop Manager", version="1.0.0")
 app.add_middleware(
     CORSMiddleware,
@@ -23,6 +42,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+anemia_model: Optional[Any] = None
 
 
 class CustomerCreate(BaseModel):
@@ -83,9 +104,80 @@ class ChatMessage(ChatMessageCreate):
     created_at: datetime
 
 
+class AnemiaPredictionInput(BaseModel):
+    RIDAGEYR: float
+    RIAGENDR: float
+    RIDEXPRG: float
+    LBXIRN: float
+    LBXUIB: float
+    LBDTIB: float
+    LBDPCT: float
+    LBXFER: float
+    LBXHSCRP: float
+    LBXRBCSI: float
+    LBXMCVSI: float
+    LBXMCHSI: float
+    LBXMC: float
+    LBXRDW: float
+
+
+class AnemiaPredictionResponse(BaseModel):
+    prediction: float
+    prediction_label: Optional[str]
+    probability: Optional[float]
+
+
 @app.on_event("startup")
 async def startup_event() -> None:
+    global anemia_model
     init_db()
+    if MODEL_PATH.exists():
+        import importlib
+
+        try:
+            joblib = importlib.import_module("joblib")
+        except ModuleNotFoundError as exc:
+            raise RuntimeError("Instala joblib para cargar el modelo de anemia") from exc
+        anemia_model = joblib.load(MODEL_PATH)
+
+
+def _build_feature_row(payload: AnemiaPredictionInput) -> List[float]:
+    as_dict = payload.dict()
+    return [as_dict[name] for name in FEATURES]
+
+
+@app.get("/anemia/features", response_model=List[str])
+async def get_anemia_features() -> List[str]:
+    return FEATURES
+
+
+@app.post("/anemia/predict", response_model=AnemiaPredictionResponse)
+async def predict_anemia(payload: AnemiaPredictionInput) -> AnemiaPredictionResponse:
+    if anemia_model is None:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Modelo no cargado. Coloca tu archivo joblib en "
+                f"{MODEL_PATH} o define ANEMIA_MODEL_PATH"
+            ),
+        )
+
+    feature_row = _build_feature_row(payload)
+    prediction = float(anemia_model.predict([feature_row])[0])
+
+    probability: Optional[float] = None
+    if hasattr(anemia_model, "predict_proba"):
+        probability = float(anemia_model.predict_proba([feature_row])[0][1])
+
+    prediction_label: Optional[str] = None
+    if prediction in {0.0, 1.0}:
+        prediction_label = "anemia" if prediction == 1.0 else "sin_anemia"
+
+    return AnemiaPredictionResponse(
+        prediction=prediction,
+        prediction_label=prediction_label,
+        probability=probability,
+    )
 
 
 @app.post("/customers", response_model=Customer, status_code=201)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.110.1
 uvicorn[standard]==0.29.0
 pydantic==1.10.14
 python-multipart==0.0.9
+joblib==1.4.2


### PR DESCRIPTION
### Motivation
- Integrar una demo de inferencia para un modelo de predicción de anemia serializado con `joblib` usando la lista de `FEATURES` provista.
- Exponer una API sencilla para inspeccionar las features esperadas y realizar predicciones sin hemoglobina.

### Description
- Añadido el array `FEATURES`, la variable `MODEL_PATH` (lectura desde `ANEMIA_MODEL_PATH`) y carga del modelo en `startup` usando `joblib` con un error claro si `joblib` no está presente.
- Nuevos modelos Pydantic `AnemiaPredictionInput` y `AnemiaPredictionResponse` y función auxiliar `_build_feature_row` para construir la fila de entrada al modelo.
- Nuevos endpoints `GET /anemia/features` y `POST /anemia/predict` que devuelven `prediction`, `prediction_label` y `probability` cuando el modelo implementa `predict_proba`.
- Actualizado `README.md` con instrucciones de uso y ejemplo `curl`, y agregado `joblib==1.4.2` en `requirements.txt`.

### Testing
- Ejecutado `python -m py_compile app/main.py` con resultado exitoso.
- Ejecutado un script que instancia `AnemiaPredictionInput` y llama a `_build_feature_row`, que devolvió correctamente una fila de 14 elementos.
- Intentado `pip install -r requirements.txt` pero la descarga de `joblib` falló por restricciones de red/proxy, por lo que la carga real del modelo no pudo verificarse en este entorno.
- Intento de usar `fastapi.TestClient` falló porque `httpx` no estaba instalado, por lo que no se realizaron pruebas de integración HTTP completas.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ac59e21208329adec9e63ba991dfa)